### PR TITLE
docs: 完善 Actions Secret 安全配置与运行前校验

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,16 @@
 name: 刷课
  
-on: 
-  push:
-    branches: [ main ]
+on:
+  workflow_dispatch:
   #是否开始每天8点定时刷课，若要开启请把下面两行注释去掉
   #schedule:
-  #  - cron: "0 8 * * *" 
-    
-jobs: 
+  #  - cron: "0 8 * * *"
+
+# 工作流只需要读取仓库内容；不要授予写入或部署权限。
+permissions:
+  contents: read
+
+jobs:
   Start:
     runs-on: ubuntu-latest # 在最新版本的 Ubuntu 操作系统环境下运行
     steps: # 要执行的步骤
@@ -21,9 +24,18 @@ jobs:
  
       - name: 安装依赖包
         run: | # 安装依赖包
-          pip install -r ./requirements.txt 
-          
-      
+          pip install -r ./requirements.txt
+
+      - name: 检查必填 Secrets
+        env:
+          CHAOXING_USERNAME: ${{ secrets.CHAOXING_USERNAME }}
+          CHAOXING_PASSWORD: ${{ secrets.CHAOXING_PASSWORD }}
+          CHAOXING_COURSE_LIST: ${{ secrets.CHAOXING_COURSE_LIST }}
+        run: |
+          test -n "$CHAOXING_USERNAME" || (echo "缺少 CHAOXING_USERNAME Secret" >&2; exit 1)
+          test -n "$CHAOXING_PASSWORD" || (echo "缺少 CHAOXING_PASSWORD Secret" >&2; exit 1)
+          test -n "$CHAOXING_COURSE_LIST" || (echo "缺少 CHAOXING_COURSE_LIST Secret" >&2; exit 1)
+
       - name: Run main.py
         env:
           CHAOXING_USERNAME: ${{ secrets.CHAOXING_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -14,10 +14,21 @@
 
 ![截图](/images/star.png)
 
-## 用前必读必读！
-默认fork仓库之后是公开的状态，也就是说你的账号和密码是处于一个明文状态！！很危险！！建议把仓库权限改为私有
+## 安全配置（必读）
 
-之前本仓库就因为明文账号密码泄露导致一些同学账号被盗拿来恶作剧(不得不说世界上还是坏人多)，故提前在此说明，希望大家周知
+不要将账号、密码或 Cookie 写入仓库文件、代码提交、Issue、日志或截图。Fork 仓库通常仍属于原 Fork 网络，不能直接改为私有；如需独立私有仓库，须先在 GitHub 的仓库设置中选择 **Leave fork network**。私有仓库的 Actions 可能受账户分钟配额限制。
+
+推荐将凭据存放在 GitHub Actions Secrets：进入 Fork 后仓库的 **Settings → Secrets and variables → Actions → New repository secret**，创建下列三个 Secret。Secret 的值不会显示在 Actions 日志中；请勿在日志中打印它们。
+
+| Secret 名称 | 必填 | 值的格式与示例 |
+| --- | --- | --- |
+| `CHAOXING_USERNAME` | 是 | 账号字符串，例如 `your_name` |
+| `CHAOXING_PASSWORD` | 是 | 密码字符串，例如 `your_password` |
+| `CHAOXING_COURSE_LIST` | 是 | 课程 ID 的逗号分隔字符串，例如 `114514,1919810`（不要填写方括号或引号） |
+
+工作流只支持手动触发：在 **Actions → 刷课 → Run workflow** 中运行。这样提交 README 或配置等普通改动不会意外执行工作流。
+
+若在本地使用配置文件，请从 `config_template.ini` 复制出 `config.ini`，仅保存在本机。`config.ini` 和 `cookies.txt` 已被 `.gitignore` 排除，但提交前仍请检查 `git status`，避免凭据进入版本库。
 
 ## 快速开始
 


### PR DESCRIPTION
## 改动说明

- 修正 Fork 仓库与私有化的安全说明，补充 GitHub Actions Secrets 的配置方式和课程列表格式。
- 将工作流改为手动触发，并将 `GITHUB_TOKEN` 权限限制为只读。
- 在运行主程序前检查三个必填 Secret；缺失时给出明确错误且不输出 Secret 值。
- 仅在校验和主程序步骤注入 Secret，避免传递给代码检出和依赖安装步骤。

## 验证

- 使用 Python 3.13 运行 `main.py --help`
- 全量 Python 源码编译
- 工作流 YAML 与权限/Secret 作用域策略校验

Closes #65

Related to #63